### PR TITLE
Add BladeJavaJar builder for Java

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -313,8 +313,8 @@ class JavaTarget(Target, JavaTargetMixIn):
 
 class JavaLibrary(JavaTarget):
     """JavaLibrary"""
-    def __init__(self, name, srcs, deps, resources, source_encoding, warnings,
-                 prebuilt, binary_jar, exported_deps, kwargs):
+    def __init__(self, name, srcs, deps, resources, source_encoding,
+                 warnings, prebuilt, binary_jar, exported_deps, kwargs):
         type = 'java_library'
         if prebuilt:
             type = 'prebuilt_java_library'
@@ -396,10 +396,9 @@ class JavaTest(JavaBinary):
 
 class JavaFatLibrary(JavaTarget):
     """JavaFatLibrary"""
-    def __init__(self, name, srcs, deps, resources, source_encoding,
-                 warnings, kwargs):
-        JavaTarget.__init__(self, name, 'java_fat_library', srcs, deps, resources,
-                            source_encoding, warnings, kwargs)
+    def __init__(self, name, srcs, deps, resources, source_encoding, warnings, kwargs):
+        JavaTarget.__init__(self, name, 'java_fat_library', srcs, deps,
+                            resources, source_encoding, warnings, kwargs)
 
     def scons_rules(self):
         self._prepare_to_generate_rule()

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -434,13 +434,8 @@ def _generate_jar(target, sources, resources, env):
     global option_verbose
     if option_verbose:
         print cmd
-    p = subprocess.Popen(cmd,
-                         env=os.environ,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         shell=True,
-                         universal_newlines=True)
-    stdout, stderr = p.communicate()
+    p = subprocess.Popen(cmd, env=os.environ, shell=True)
+    p.communicate()
     return p.returncode
 
 

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -410,6 +410,8 @@ def _generate_jar(target, sources, resources, env):
             if not source.endswith('.class'):
                 continue
 
+            # Add the source from sources produced by Java builder
+            # no matter it's a normal class or inner class
             jar_path = os.path.relpath(source, classes_dir)
             if jar_path not in jar_path_set:
                 jar_path_set.add(jar_path)


### PR DESCRIPTION
Add BladeJavaJar builder using glob and timestamp to collect generate *.class  files based on the results of Java builder.
Jar builder of scons have bugs to detect generated inner class files. See:
http://scons.tigris.org/issues/show_bug.cgi?id=1594
http://scons.tigris.org/issues/show_bug.cgi?id=2742
