### PR TITLE
Blade provided_deps

### DIFF
--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -108,6 +108,9 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         proto_name = src[:-6]
         return self._target_file_path('%s_pb2.py' % proto_name)
 
+    def _get_java_pack_deps(self):
+        return self._get_pack_deps()
+
     def _get_java_package_name(self, content):
         """Get the java package name from proto file if it is specified. """
         java_package_pattern = '^\s*option\s*java_package\s*=\s*["\']([\w.]+)'

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -226,6 +226,22 @@ class Target(object):
         """
         pass
 
+    def _get_java_pack_deps(self):
+        """_get_java_pack_deps
+        
+        Returns
+        -----------
+        A tuple of (scons vars, jars)
+        
+        Description
+        -----------
+        Return java package dependencies excluding provided dependencies
+        scons vars represent targets to be built later
+        jars represent prebuilt jars or maven artifacts within local repository
+        
+        """
+        return [], []
+
     def _regular_variable_name(self, var):
         """_regular_variable_name.
 


### PR DESCRIPTION
Change provided_deps implementation to be consistent with maven:
Assume A,B,C,D,E is java_library and X is java_binary, X --> A means A is a dependency of X

1. X --> A --> B --> C/D and B is a provided dependency of A, then X.jar will ONLY contain A
2. X --> A --> B --> C/D and B is a provided dependency of A,

    X --> E --> C
then X.jar will contain A，E，C
                       