### PR TITLE
Add source_encoding for scala targets

### DIFF
--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -84,6 +84,7 @@ class BladeConfig(object):
             'scala_config': {
                 'scala_home' : '',
                 'warnings' : '',
+                'source_encoding' : None,
             },
             'scala_test_config': {
                 'scalatest_libs' : '',

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -620,13 +620,13 @@ def _generate_scala_jar(target, sources, resources, env):
     """
     scalac = env['SCALAC']
     jar = env['JAR']
-    warnings = env['SCALACFLAGS']
+    options = ' '.join(env['SCALACFLAGS'])
     classpath = ':'.join(env['JAVACLASSPATH'])
     if not classpath:
         classpath = blade_util.get_cwd()
 
     cmd = '%s -d %s -classpath %s %s %s' % (scalac, target, classpath,
-            warnings, ' '.join(sources))
+            options, ' '.join(sources))
     global option_verbose
     if option_verbose:
         print cmd


### PR DESCRIPTION
Scala compiler man page:
> -encoding \<encoding>
        Specify character encoding used by source files.
        The default value is platform-specific (Linux: "UTF8", Windows: "Cp1252"). Executing the following        code in the Scala interpreter will return the default value on your system:
        scala> new java.io.InputStreamReader(System.in).getEncoding