### PR TITLE
Detect maven dependency conflict

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -12,6 +12,7 @@ Implement java_library, java_binary, java_test and java_fat_library
 
 import os
 import re
+from distutils.version import LooseVersion
 
 import blade
 import blade_util
@@ -74,7 +75,7 @@ class JavaTargetMixIn(object):
         self.expanded_deps.append(key)
         return key
 
-    def _collect_maven_dep_ids(self):
+    def _get_maven_dep_ids(self):
         maven_dep_ids = set()
         for dkey in self.deps:
             dep = self.target_database[dkey]
@@ -170,7 +171,7 @@ class JavaTargetMixIn(object):
         dependency of the target
         """
         dep_jars, conflicted_jars = set(dep_jars), set()
-        maven_dep_ids = self._collect_maven_dep_ids()
+        maven_dep_ids = self._get_maven_dep_ids()
         maven_jar_dict = {}  # (group, artifact) -> (version, name, jar)
         maven_repo = '.m2/repository/'
         for dep_jar in dep_jars:
@@ -188,7 +189,7 @@ class JavaTargetMixIn(object):
                 old_id = ':'.join((group, artifact, old_value[0]))
                 if old_id in maven_dep_ids:
                     conflicted_jars.add(dep_jar)
-                elif id in maven_dep_ids or version > old_value[0]:
+                elif id in maven_dep_ids or LooseVersion(version) > LooseVersion(old_value[0]):
                     conflicted_jars.add(old_value[2])
                     maven_jar_dict[key] = (version, name, dep_jar)
                 else:

--- a/src/blade/maven.py
+++ b/src/blade/maven.py
@@ -171,7 +171,7 @@ class MavenCache(object):
         if not id in self.__jar_database:
             success = self._download_artifact(id)
             if not success:
-                console.error('Download %s failed' % id)
+                console.warning('Download %s failed' % id)
                 return '';
         if jar:
             return self.__jar_database[id][0]


### PR DESCRIPTION
### Maven dependencies might have conflict: same group and artifact but different version. Select version according to the following rules:
1. Select the version if it's explicitly specified as a direct dependency
2. Select higher version if #1 is not satisfied

![1](https://cloud.githubusercontent.com/assets/14238472/11560362/ed9a45de-99fa-11e5-8818-34d0f9174b27.png)

