### PR TITLE
Copy resources from main jar and dependencies to onejar

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -171,12 +171,10 @@ class JavaTargetMixIn(object):
                 else:
                     conflicted_jars.add(dep_jar)
                 value = maven_jar_dict[key]
-                console.warning('%s: Detect maven dependency conflict between'
-                                ' %s and %s during %s. Use %s' % (
-                                self.fullname, id,
-                                ':'.join([key[0], key[1], old_value[0]]),
-                                scope,
-                                ':'.join([key[0], key[1], value[0]])))
+                console.warning('%s: Maven dependency version conflict '
+                                '%s:%s:{%s, %s} during %s. Use %s' % (
+                                self.fullname, key[0], key[1],
+                                version, old_value[0], scope, value[0]))
             else:
                 maven_jar_dict[key] = (version, set([dep_jar]))
 
@@ -498,14 +496,13 @@ class JavaTest(JavaBinary):
         self._prepare_to_generate_rule()
         self._generate_jar()
         dep_jar_vars, dep_jars = self._get_test_deps()
-        self._generate_wrapper(self._generate_one_jar(dep_jar_vars, dep_jars),
-                               dep_jar_vars)
+        self._generate_wrapper(self._generate_one_jar(dep_jar_vars, dep_jars))
 
-    def _generate_wrapper(self, onejar, dep_jar_vars):
+    def _generate_wrapper(self, onejar):
         var_name = self._var_name()
-        self._write_rule('%s = %s.JavaTest(target="%s", source=[%s, %s] + [%s])' % (
+        self._write_rule('%s = %s.JavaTest(target="%s", source=[%s, %s])' % (
             var_name, self._env_name(), self._target_file_path(),
-            onejar, self.data['jar_var'], ','.join(dep_jar_vars)))
+            onejar, self.data['jar_var']))
 
 
 class JavaFatLibrary(JavaTarget):

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -486,17 +486,19 @@ def _generate_one_jar(target,
     for dep in deps_jar:
         dep_name = os.path.basename(dep)
         target_one_jar.write(dep, os.path.join('lib', dep_name))
-        # Copy resources from the dependency to the root of target jar
-        dep_jar = zipfile.ZipFile(dep, 'r')
-        dep_name_list = dep_jar.namelist()
-        for name in dep_name_list:
+
+    # Copy resources to the root of target onejar
+    for jar in [main_jar] + deps_jar:
+        jar = zipfile.ZipFile(jar, 'r')
+        jar_name_list = jar.namelist()
+        for name in jar_name_list:
             if name.endswith('.class') or name.upper().startswith('META-INF'):
                 continue
-            data = dep_jar.read(name)
+            data = jar.read(name)
             if data and name not in jar_path_set:
                 jar_path_set.add(name)
                 target_one_jar.writestr(name, data)
-        dep_jar.close()
+        jar.close()
 
     # Manifest
     # Note that the manifest file must end with a new line or carriage return

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -470,12 +470,14 @@ def _generate_one_jar(target,
         os.makedirs(target_dir)
 
     target_one_jar = zipfile.ZipFile(target, 'w')
+    jar_path_set = set()
     # Copy files from one-jar-boot.jar to the target jar
     zip_file = zipfile.ZipFile(one_jar_boot_path, 'r')
     name_list = zip_file.namelist()
     for name in name_list:
         if not name.lower().endswith('manifest.mf'): # Exclude manifest
             target_one_jar.writestr(name, zip_file.read(name))
+            jar_path_set.add(name)
     zip_file.close()
 
     # Main jar and dependencies
@@ -484,6 +486,17 @@ def _generate_one_jar(target,
     for dep in deps_jar:
         dep_name = os.path.basename(dep)
         target_one_jar.write(dep, os.path.join('lib', dep_name))
+        # Copy resources from the dependency to the root of target jar
+        dep_jar = zipfile.ZipFile(dep, 'r')
+        dep_name_list = dep_jar.namelist()
+        for name in dep_name_list:
+            if name.endswith('.class') or name.upper().startswith('META-INF'):
+                continue
+            data = dep_jar.read(name)
+            if data and name not in jar_path_set:
+                jar_path_set.add(name)
+                target_one_jar.writestr(name, data)
+        dep_jar.close()
 
     # Manifest
     # Note that the manifest file must end with a new line or carriage return
@@ -602,12 +615,10 @@ def _get_all_test_class_names_in_jar(jar):
 
 
 def generate_java_test(target, source, env):
-    """build function to generate wrapper shell script for java binary"""
+    """build function to generate wrapper shell script for java test"""
     target_name = str(target[0])
     onejar_path = str(source[0])
-    test_class_names = []
-    for src in source[1:]:
-        test_class_names += _get_all_test_class_names_in_jar(str(src))
+    test_class_names = _get_all_test_class_names_in_jar(str(source[1]))
 
     return _generate_java_binary(target_name, onejar_path, '',
                                  ' '.join(test_class_names))


### PR DESCRIPTION
#### Changes:
  1. Copy resources from dependencies when generating one jar
  2. Simplify warning message for maven dependency conflict
  3. Only search the current test jar for test classes