### PR TITLE
Java Coverage with JaCoCo: part 1

### DIFF
--- a/src/blade/command_args.py
+++ b/src/blade/command_args.py
@@ -256,6 +256,11 @@ class CmdArguments(object):
             action='store_true', default=False,
             help='Add build options to support GNU gcov to do coverage test.')
 
+        parser.add_argument(
+            '--coverage', dest='coverage',
+            action='store_true', default=False,
+            help='Add build options to support coverage test.')
+
     def _add_query_arguments(self, parser):
         """Add query arguments for parser. """
         self.__add_plat_profile_arguments(parser)

--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -80,6 +80,7 @@ class BladeConfig(object):
             },
             'java_test_config': {
                 'junit_libs' : [],
+                'jacoco_home' : '',
             },
             'scala_config': {
                 'scala_home' : '',

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -368,6 +368,18 @@ class JavaTargetMixIn(object):
                 self._target_file_path() + '.jar', ','.join(sources)))
             self.data['jar_var'] = var_name
 
+    def _generate_fat_jar(self, dep_jar_vars, dep_jars):
+        var_name = self._var_name('fatjar')
+        jar_vars = []
+        if self.data.get('jar_var'):
+            jar_vars = [self.data.get('jar_var')]
+        jar_vars.extend(dep_jar_vars)
+        self._write_rule('%s = %s.FatJar(target="%s", source=[%s] + %s)' % (
+            var_name, self._env_name(),
+            self._target_file_path() + '.fat.jar',
+            ','.join(jar_vars), dep_jars))
+        return var_name
+
 
 class JavaTarget(Target, JavaTargetMixIn):
     """A java jar target subclass.
@@ -516,20 +528,8 @@ class JavaFatLibrary(JavaTarget):
         dep_jars = self._detect_maven_conflicted_deps('package', dep_jars)
         self._generate_fat_jar(dep_jar_vars, dep_jars)
 
-    def _generate_fat_jar(self, dep_jar_vars, dep_jars):
-        var_name = self._var_name('fatjar')
-        jar_vars = []
-        if self.data.get('jar_var'):
-            jar_vars = [self.data.get('jar_var')]
-        jar_vars.extend(dep_jar_vars)
-        self._write_rule('%s = %s.FatJar(target="%s", source=[%s] + %s)' % (
-            var_name, self._env_name(),
-            self._target_file_path() + '.fat.jar',
-            ','.join(jar_vars), dep_jars))
-        return var_name
 
-
-class JavaTest(JavaBinary, JavaFatLibrary):
+class JavaTest(JavaBinary):
     """JavaTarget"""
     def __init__(self, name, srcs, deps, resources, source_encoding,
                  warnings, main_class, packaging, testdata, target_under_test, kwargs):

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -227,8 +227,23 @@ class JavaTargetMixIn(object):
 
         return sorted(list(dep_jar_vars)), sorted(list(dep_jars))
 
-    def _get_java_package_name(self, file_name):
-        """Get the java package name from proto file if it is specified. """
+    def _get_java_package_name(self):
+        """
+        Get java package name. Usually all the sources are within the same package.
+        However, there are cases where BUILD is in the parent directory and sources
+        are located in subdirectories each of which defines its own package.
+        """
+        if not self.srcs:
+            return []
+        packages = set()
+        for src in self.srcs:
+            package = self._get_source_package_name(self._source_file_path(src))
+            if package:
+                packages.add(package)
+        return sorted(list(packages))
+
+    def _get_source_package_name(self, file_name):
+        """Get the java package name from source file if it is specified. """
         if not os.path.isfile(file_name):
             return ''
         package_pattern = '^\s*package\s+([\w.]+)'
@@ -252,7 +267,7 @@ class JavaTargetMixIn(object):
                 if pos > 0:
                     path.add(src[:pos + len(seg)])
                     continue
-            package = self._get_java_package_name(src)
+            package = self._get_source_package_name(src)
             if package:
                 package = package.replace('.', '/') + '/'
                 pos = src.find(package)
@@ -488,18 +503,31 @@ class JavaBinary(JavaTarget):
 class JavaTest(JavaBinary):
     """JavaTarget"""
     def __init__(self, name, srcs, deps, resources, source_encoding,
-                 warnings, main_class, testdata, kwargs):
+                 warnings, main_class, testdata, target_under_test, kwargs):
         java_test_config = configparse.blade_config.get_config('java_test_config')
         JavaBinary.__init__(self, name, srcs, deps, resources,
                             source_encoding, warnings, main_class, None, kwargs)
         self.type = 'java_test'
         self.data['testdata'] = var_to_list(testdata)
+        if target_under_test:
+            self.data['target_under_test'] = self._unify_dep(target_under_test)
 
     def scons_rules(self):
         self._prepare_to_generate_rule()
         self._generate_jar()
         dep_jar_vars, dep_jars = self._get_test_deps()
         self._generate_wrapper(self._generate_one_jar(dep_jar_vars, dep_jars))
+
+    def _prepare_to_generate_rule(self):
+        JavaBinary._prepare_to_generate_rule(self)
+        self._generate_target_under_test_package()
+
+    def _generate_target_under_test_package(self):
+        target_under_test = self.data.get('target_under_test')
+        if target_under_test:
+            target = self.target_database[target_under_test]
+            self._write_rule('%s.Append(JAVATARGETUNDERTESTPKG=%s)' % (
+                self._env_name(), target._get_java_package_name()))
 
     def _generate_wrapper(self, onejar):
         var_name = self._var_name()
@@ -597,6 +625,7 @@ def java_test(name,
               warnings=None,
               main_class = 'org.junit.runner.JUnitCore',
               testdata=[],
+              target_under_test='',
               **kwargs):
     """Define java_test target. """
     target = JavaTest(name,
@@ -607,6 +636,7 @@ def java_test(name,
                       warnings,
                       main_class,
                       testdata,
+                      target_under_test,
                       kwargs)
     blade.blade.register_target(target)
 

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -293,6 +293,14 @@ import scons_helper
     def _setup_cache(self):
         self.build_environment.setup_build_cache(self.options)
 
+    def generate_extra_flags(self):
+        if getattr(self.options, 'coverage', False):
+            config = configparse.blade_config.get_config('java_test_config')
+            jacoco_home = config['jacoco_home']
+            if jacoco_home:
+                jacoco_agent = os.path.join(jacoco_home, 'lib', 'jacocoagent.jar')
+                self._add_rule('top_env.Replace(JACOCOAGENT="%s")' % jacoco_agent)
+
     def generate(self, blade_path):
         """Generates all rules. """
         self.generate_imports_functions(blade_path)
@@ -300,6 +308,7 @@ import scons_helper
         self.generate_compliation_verbose()
         self.generate_builders()
         self.generate_compliation_flags()
+        self.generate_extra_flags()
         self.generate_version_file()
         return self.rules_buf
 

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -294,12 +294,11 @@ import scons_helper
         self.build_environment.setup_build_cache(self.options)
 
     def generate_extra_flags(self):
-        if getattr(self.options, 'coverage', False):
-            config = configparse.blade_config.get_config('java_test_config')
-            jacoco_home = config['jacoco_home']
-            if jacoco_home:
-                jacoco_agent = os.path.join(jacoco_home, 'lib', 'jacocoagent.jar')
-                self._add_rule('top_env.Replace(JACOCOAGENT="%s")' % jacoco_agent)
+        config = configparse.blade_config.get_config('java_test_config')
+        jacoco_home = config['jacoco_home']
+        if jacoco_home:
+            jacoco_agent = os.path.join(jacoco_home, 'lib', 'jacocoagent.jar')
+            self._add_rule('top_env.Replace(JACOCOAGENT="%s")' % jacoco_agent)
 
     def generate(self, blade_path):
         """Generates all rules. """

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -133,18 +133,6 @@ class ScalaFatLibrary(ScalaTarget):
         dep_jars = self._detect_maven_conflicted_deps('package', dep_jars)
         self._generate_fat_jar(dep_jar_vars, dep_jars)
 
-    def _generate_fat_jar(self, dep_jar_vars, dep_jars):
-        var_name = self._var_name('fatjar')
-        jar_vars = []
-        if self.data.get('jar_var'):
-            jar_vars = [self.data.get('jar_var')]
-        jar_vars.extend(dep_jar_vars)
-        self._write_rule('%s = %s.FatJar(target="%s", source=[%s] + %s)' % (
-            var_name, self._env_name(),
-            self._target_file_path() + '.fat.jar',
-            ','.join(jar_vars), dep_jars))
-        return var_name
-
 
 class ScalaTest(ScalaFatLibrary):
     """ScalaTest"""

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -615,6 +615,24 @@ def _get_all_test_class_names_in_jar(jar):
     return test_class_names
 
 
+def _generate_java_test_flags(env):
+    """Returns jvm runtime flags based on the environment passed in. """
+    jvm_flags = []
+    env_dict = env.Dictionary()
+    jacoco_agent = env_dict.get('JACOCOAGENT')
+    if jacoco_agent:
+        jacoco_agent = os.path.abspath(jacoco_agent)
+        target_under_test_package = env_dict.get('JAVATARGETUNDERTESTPKG')
+        if target_under_test_package:
+            options = []
+            options.append('includes=%s' % ':'.join(
+                [p + '.*' for p in target_under_test_package if p]))
+            options.append('output=file')
+            jvm_flags.append('-javaagent:%s=%s' % (jacoco_agent, ','.join(options)))
+
+    return ' '.join(jvm_flags)
+
+
 def generate_java_test(target, source, env):
     """build function to generate wrapper shell script for java test"""
     target_name = str(target[0])
@@ -622,7 +640,8 @@ def generate_java_test(target, source, env):
     test_jar = str(source[1])
     test_class_names = _get_all_test_class_names_in_jar(test_jar)
 
-    return _generate_java_binary(target_name, onejar_path, '',
+    return _generate_java_binary(target_name, onejar_path,
+                                 _generate_java_test_flags(env),
                                  ' '.join(test_class_names))
 
 


### PR DESCRIPTION
### Java Coverge with JaCoCo
1. Add --coverage in build options to add jacoco agent for shell script of java_test
2. Add target_under_test in java_test to declare the testing target. Currently only support one target.

![1](https://cloud.githubusercontent.com/assets/14238472/12030327/110c2360-ae38-11e5-800c-b21540547c9e.png)
