### PR TITLE
Export deps recursively

### DIFF
--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -60,7 +60,14 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         # Hardcode deps rule to thirdparty protobuf lib.
         self._add_hardcode_library(protobuf_libs)
         self._add_hardcode_java_library(protobuf_java_libs)
-        self.data['exported_deps'] = self._unify_deps(protobuf_java_libs)
+
+        # Normally a proto target depends on another proto target when
+        # it references a message defined in that target. Then in the
+        # generated code there is public API with return type/arguments
+        # defined outside and in java it needs to export that dependency,
+        # which is also the case for java protobuf library.
+        self.data['exported_deps'] = self._unify_deps(var_to_list(deps))
+        self.data['exported_deps'] += self._unify_deps(protobuf_java_libs)
 
         # Link all the symbols by default
         self.data['link_all_symbols'] = True


### PR DESCRIPTION
#### Export deps recursively

* Exported_deps is used when public API of a target has return types/arguments defined in another target. This should be recursive as follows:
                                   
>    A <------ B <------exported_dep--- C <-----exported_dep--- D
>   Before change when compiling A: classpath: B + C
>   After change when compiling A:    classpath: B + C + D

* Proto_library is very typical that it should export all the dependencies because it references a message defined in another proto target and has public APIs with return type/arguments in the generated code.