### PR TITLE
Transitive in maven_jar

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -35,10 +35,7 @@ class MavenJar(Target):
         self.data['transitive'] = transitive
 
     def _get_java_pack_deps(self):
-        deps = []
-        if self.data.get('transitive'):
-            deps = self.data.get('maven_deps', [])
-        return [], deps
+        return [], self.data.get('maven_deps', [])
 
     def scons_rules(self):
         maven_cache = maven.MavenCache.instance(blade.blade.get_build_path())
@@ -46,10 +43,11 @@ class MavenJar(Target):
                                               self.data['classifier'])
         if binary_jar:
             self.data['binary_jar'] = binary_jar
-            deps_path = maven_cache.get_jar_deps_path(self.data['id'],
-                                                      self.data['classifier'])
-            if deps_path:
-                self.data['maven_deps'] = deps_path.split(':')
+            if self.data.get('transitive'):
+                deps_path = maven_cache.get_jar_deps_path(
+                    self.data['id'], self.data['classifier'])
+                if deps_path:
+                    self.data['maven_deps'] = deps_path.split(':')
 
 
 class JavaTargetMixIn(object):


### PR DESCRIPTION
1. By default maven cache downloads the specified artifact and all of its dependencies transitively

2. When #1 failed, try to download the specified artifact individually and issue the warning that transitive dependencies are not available

![1](https://cloud.githubusercontent.com/assets/14238472/13136993/ef305bbe-d658-11e5-9dbf-f7baf5455af0.png)
