### PR TITLE
Fix KeyError when querying depended targets

### DIFF
--- a/src/blade/dependency_analyzer.py
+++ b/src/blade/dependency_analyzer.py
@@ -134,6 +134,8 @@ def _topological_sort(pairlist):
     for second, target in pairlist.items():
         if second not in numpreds:
             numpreds[second] = 0
+        if second not in successors:
+            successors[second] = []
         deps = target.expanded_deps
         for first in deps:
             # make sure every elt is a key in numpreds


### PR DESCRIPTION
In topological sorting, initialize targets which is an ending target(no other targets depend on it. Out-degree is zero in the dependency graph) with empty list.

![1](https://cloud.githubusercontent.com/assets/14238472/13208957/51ccda10-d959-11e5-8840-7b40cedcefcb.png)
