### PR TITLE
Re-implement jar resource handling

### DIFF
--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -459,8 +459,7 @@ class JavaTargetMixIn(object):
         for i, resource in enumerate(resources):
             src, dst = resource[0], os.path.join(resources_dir, resource[1])
             res_var = self._var_name('resources__%s' % i)
-            self._write_rule('%s = %s.Command(target = "%s", source = "%s", '
-                             'action = Copy("$TARGET", "$SOURCE"))' %
+            self._write_rule('%s = %s.JavaResource(target = "%s", source = "%s")' %
                              (res_var, env_name, dst, src))
             self._write_rule('%s.append(%s)' % (resources_var_name, res_var))
             self._write_rule('%s.append("%s")' % (resources_path_var_name, dst))

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -89,14 +89,18 @@ class ScalaTarget(Target, JavaTargetMixIn):
         # Do not generate jar when there is no source
         if not sources:
             return
+        env_name = self._env_name()
         var_name = self._var_name('jar')
         dep_jar_vars, dep_jars = self._get_compile_deps()
         self._generate_java_classpath(dep_jar_vars, dep_jars)
-        resources_var = self._generate_resources()
+        resources_var, resources_path_var = self._generate_resources()
         self._write_rule('%s = %s.ScalaJar(target="%s", source=%s + [%s])' % (
-            var_name, self._env_name(),
+            var_name, env_name,
             self._target_file_path() + '.jar', sources, resources_var))
         self._generate_java_depends(var_name, dep_jar_vars, dep_jars)
+        if resources_var:
+            self._write_rule('%s.Depends(%s, Value(%s))' % (
+                env_name, var_name, resources_path_var))
         self.data['jar_var'] = var_name
 
 

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -388,11 +388,8 @@ def _emit_java_resources(target, source, env):
 
 
 def process_java_resources(target, source, env):
-    """Copy source resource file into .resources dir"""
-    target_dir = str(target[0].attributes.java_classdir)
-    for src in source:
-        target_path = os.path.join(target_dir, src.attributes.target_path)
-        shutil.copy2(str(src), target_path)
+    """Copy source resource file into .resources dir. """
+    shutil.copy2(str(source[0]), str(target[0]))
     return None
 
 
@@ -1228,11 +1225,7 @@ def setup_java_builders(top_env, java_home, one_jar_boot_path):
     resource_message = console.erasable('%sProcess jar resource %s$SOURCES%s%s' % ( \
         colors('cyan'), colors('purple'), colors('cyan'), colors('end')))
     java_resource_bld = SCons.Builder.Builder(
-            action = MakeAction(
-                process_java_resources, resource_message),
-            emitter = _emit_java_resources,
-            target_factory = SCons.Node.FS.Entry,
-            source_factory = SCons.Node.FS.Entry)
+        action = MakeAction(process_java_resources, resource_message))
     top_env.Append(BUILDERS = {"JavaResource" : java_resource_bld})
 
     global _one_jar_boot_path


### PR DESCRIPTION
## Jar resource handling
### resource supports the following:
1. relative file/directory to the current source directory.

    - Specify the mapping path explicitly
    - Generate the mapping path if source resource path satisfies maven rules
    - Generate the mapping path literally

2. absolute file/directory from the blade root directory

    - Specify the mapping path explicitly
    - Generate the mapping path literally

![resources](https://cloud.githubusercontent.com/assets/14238472/13277537/928ae770-db04-11e5-8059-1ae091a2697c.png)
![mapping](https://cloud.githubusercontent.com/assets/14238472/13277574/c13e90c6-db04-11e5-911a-64a6bd910172.png)
### test
- Test all the resources formats above

- Test incremental build
    - Change a source file
    - Add/Remove a source file/directory
    - Change mapping path

![test](https://cloud.githubusercontent.com/assets/14238472/13277536/928821de-db04-11e5-95b5-a68d774ca08f.png)