### PR TITLE
print out warnings instead of exit with errors for unrecognized options

### DIFF
--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -77,7 +77,7 @@ class Target(object):
 
     def _check_kwargs(self, kwargs):
         if kwargs:
-            console.error_exit('//%s:%s: unrecognized options %s' % (
+            console.warning('//%s:%s: unrecognized options %s' % (
                 self.path, self.name, kwargs))
 
     # Keep the relationship of all src -> target.


### PR DESCRIPTION
Signed-off-by: liuhuahang liuhuahang@zerus.co
