### PR TITLE
Support target platform in scala_config

### DIFF
--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -185,8 +185,6 @@ class BladeConfig(object):
             if k in config:
                 if isinstance(config[k], list):
                     user_config[k] = var_to_list(user_config[k])
-                else:
-                    user_config[k] = user_config[k]
             else:
                 console.warning('%s: %s: unknown config item name: %s' %
                         (self.current_file_name, section_name, k))

--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -85,6 +85,7 @@ class BladeConfig(object):
             },
             'scala_config': {
                 'scala_home' : '',
+                'target_platform' : '',
                 'warnings' : '',
                 'source_encoding' : None,
             },

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -56,6 +56,13 @@ class ScalaTarget(Target, JavaTargetMixIn):
         if warnings:
             self.data['warnings'] = warnings
 
+    def _generate_scala_target_platform(self):
+        config = configparse.blade_config.get_config('scala_config')
+        target_platform = config['target_platform']
+        if target_platform:
+            self._write_rule('%s.Append(SCALACFLAGS=["-target:%s"])' % (
+                self._env_name(), target_platform))
+
     def _generate_scala_source_encoding(self):
         source_encoding = self.data.get('source_encoding')
         if not source_encoding:
@@ -78,6 +85,7 @@ class ScalaTarget(Target, JavaTargetMixIn):
     def _prepare_to_generate_rule(self):
         """Do some preparation before generating scons rule. """
         self._clone_env()
+        self._generate_scala_target_platform()
         self._generate_scala_source_encoding()
         self._generate_scala_warnings()
 


### PR DESCRIPTION
According to scalac manual:
&nbsp;&nbsp;&nbsp;&nbsp;-target:<target>           Target platform for object files. All JVM 1.5 targets are deprecated. (jvm-1.5,jvm-1.5-fjbg,jvm-1.5-asm,jvm-1.6,jvm-1.7,msil) default:jvm-1.6