### PR TITLE
解决build文件夹被误识别为BUILD文件的Bug

### DIFF
--- a/src/blade/load_build_files.py
+++ b/src/blade/load_build_files.py
@@ -199,7 +199,7 @@ def _load_build_file(source_dir, action_if_fail, processed_source_dirs, blade):
     old_current_source_path = blade.get_current_source_path()
     blade.set_current_source_path(source_dir)
     build_file = os.path.join(source_dir, 'BUILD')
-    if os.path.exists(build_file):
+    if os.path.exists(build_file) and not os.path.isdir(build_file):
         try:
             # The magic here is that a BUILD file is a Python script,
             # which can be loaded and executed by execfile().


### PR DESCRIPTION
#239

https://github.com/chen3feng/typhoon-blade/issues/239

在大小写不敏感的文件系统上，名为小写build的文件夹会被识别为blade的BUILD文件
进而加载失败。

一个这样的build文件夹的例子是：

https://github.com/apache/thrift/tree/0.9.3/build

本改动解决了这个问题。

Signed-off-by: Huahang Liu huahang.liu@gmail.com
