### PR TITLE
Protoc plugin

### DIFF
--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -16,7 +16,6 @@ import sys
 import console
 from blade_util import var_to_list
 from cc_targets import HEAP_CHECK_VALUES
-from proto_library_target import ProtocPlugin
 
 
 # Global config object
@@ -124,9 +123,6 @@ class BladeConfig(object):
                 # All the generated go source files will be placed
                 # into $GOPATH/src/protobuf_go_path
                 'protobuf_go_path': '',
-            },
-
-            'protoc_plugin_config' : {
             },
 
             'cc_config': {
@@ -298,14 +294,6 @@ def proto_library_config(append=None, **kwargs):
             kwargs['protobuf_incs'] = [path]
 
     blade_config.update_config('proto_library_config', append, kwargs)
-
-
-def protoc_plugin_config(**kwargs):
-    """protoc_plugin_config. """
-    if 'name' not in kwargs:
-        console.error_exit('There is no name for protoc plugin %s' % kwargs)
-    config = blade_config.get_config('protoc_plugin_config')
-    config[kwargs['name']] = ProtocPlugin(**kwargs)
 
 
 def thrift_library_config(append=None, **kwargs):

--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -303,7 +303,7 @@ def proto_library_config(append=None, **kwargs):
 def protoc_plugin(**kwargs):
     """protoc_plugin. """
     if 'name' not in kwargs:
-        console.error_exit('There is no name for protoc plugin %s' % kwargs)
+        console.error_exit("Missing 'name' in protoc_plugin parameters: %s" % kwargs)
     config = blade_config.get_config('protoc_plugin_config')
     config[kwargs['name']] = ProtocPlugin(**kwargs)
 

--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -300,8 +300,8 @@ def proto_library_config(append=None, **kwargs):
     blade_config.update_config('proto_library_config', append, kwargs)
 
 
-def protoc_plugin_config(**kwargs):
-    """protoc_plugin_config. """
+def protoc_plugin(**kwargs):
+    """protoc_plugin. """
     if 'name' not in kwargs:
         console.error_exit('There is no name for protoc plugin %s' % kwargs)
     config = blade_config.get_config('protoc_plugin_config')

--- a/src/blade/configparse.py
+++ b/src/blade/configparse.py
@@ -16,6 +16,7 @@ import sys
 import console
 from blade_util import var_to_list
 from cc_targets import HEAP_CHECK_VALUES
+from proto_library_target import ProtocPlugin
 
 
 # Global config object
@@ -123,6 +124,9 @@ class BladeConfig(object):
                 # All the generated go source files will be placed
                 # into $GOPATH/src/protobuf_go_path
                 'protobuf_go_path': '',
+            },
+
+            'protoc_plugin_config' : {
             },
 
             'cc_config': {
@@ -294,6 +298,14 @@ def proto_library_config(append=None, **kwargs):
             kwargs['protobuf_incs'] = [path]
 
     blade_config.update_config('proto_library_config', append, kwargs)
+
+
+def protoc_plugin_config(**kwargs):
+    """protoc_plugin_config. """
+    if 'name' not in kwargs:
+        console.error_exit('There is no name for protoc plugin %s' % kwargs)
+    config = blade_config.get_config('protoc_plugin_config')
+    config[kwargs['name']] = ProtocPlugin(**kwargs)
 
 
 def thrift_library_config(append=None, **kwargs):

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -112,6 +112,8 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         protoc_plugin_deps = set()
         protoc_plugin_java_deps = set()
         for plugin in plugins:
+            if plugin not in protoc_plugin_config:
+                console.error_exit('%s: Unknown plugin %s' % (self.fullname, plugin))
             p = protoc_plugin_config[plugin]
             for language, v in p.code_generation.iteritems():
                 for key in v['deps']:

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -20,45 +20,6 @@ from blade_util import var_to_list
 from cc_targets import CcTarget
 
 
-class ProtocPlugin(object):
-    """A helper class for protoc plugin.
-
-    Currently blade only supports protoc plugin which generates
-    code by use of @@protoc_insertion_point mechanism. See
-    https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.compiler.plugin.pb
-    for more details.
-
-    """
-
-    __languages = ['cpp', 'java', 'python']
-
-    def __init__(self,
-                 name,
-                 path,
-                 language,
-                 deps):
-        self.name = name
-        self.path = path
-        if language not in self.__languages:
-            console.error_exit('%s: Language %s is invalid. '
-                               'Protoc plugins in %s are supported by blade currently.' % (
-                               name, language, ', '.join(self.__languages)))
-        self.language = language
-        # Note that each plugin dep should be in the global target format
-        # since protoc plugin is defined in the global scope
-        self.deps = []
-        for dep in var_to_list(deps):
-            if dep.startswith('//'):
-                dep = dep[2:]
-            key = tuple(dep.split(':'))
-            if key not in self.deps:
-                self.deps.append(key)
-
-    def protoc_plugin_flag(self, out):
-        return '--plugin=protoc-gen-%s=%s --%s_out=%s' % (
-               self.name, self.path, self.name, out)
-
-
 class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
     """A scons proto library target subclass.
 
@@ -72,7 +33,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
                  optimize,
                  deprecated,
                  generate_descriptors,
-                 plugins,
                  source_encoding,
                  blade,
                  kwargs):
@@ -102,24 +62,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         self._add_hardcode_library(protobuf_libs)
         self._add_hardcode_java_library(protobuf_java_libs)
 
-        plugins = var_to_list(plugins)
-        self.data['protoc_plugins'] = plugins
-        # Handle protoc plugin deps according to the language
-        protoc_plugin_config = configparse.blade_config.get_config('protoc_plugin_config')
-        protoc_plugin_deps = set()
-        protoc_plugin_java_deps = set()
-        for plugin in plugins:
-            p = protoc_plugin_config[plugin]
-            for key in p.deps:
-                if key not in self.deps:
-                    self.deps.append(key)
-                if key not in self.expanded_deps:
-                    self.expanded_deps.append(key)
-                protoc_plugin_deps.add(key)
-                if p.language == 'java':
-                    protoc_plugin_java_deps.add(key)
-        self.data['protoc_plugin_deps'] = list(protoc_plugin_deps)
-
         # Normally a proto target depends on another proto target when
         # it references a message defined in that target. Then in the
         # generated code there is public API with return type/arguments
@@ -127,7 +69,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         # which is also the case for java protobuf library.
         self.data['exported_deps'] = self._unify_deps(var_to_list(deps))
         self.data['exported_deps'] += self._unify_deps(protobuf_java_libs)
-        self.data['exported_deps'] += list(protoc_plugin_java_deps)
 
         # Link all the symbols by default
         self.data['link_all_symbols'] = True
@@ -155,9 +96,8 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         protobuf_libs = var_to_list(proto_config['protobuf_libs'])
         protobuf_java_libs = var_to_list(proto_config['protobuf_java_libs'])
         protobuf_libs = [self._unify_dep(d) for d in protobuf_libs + protobuf_java_libs]
-        proto_deps = protobuf_libs + self.data['protoc_plugin_deps']
         for dkey in self.deps:
-            if dkey in proto_deps:
+            if dkey in protobuf_libs:
                 continue
             dep = self.target_database[dkey]
             if dep.type != 'proto_library' and dep.type != 'gen_rule':
@@ -335,16 +275,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         self._write_rule('%s.ProtoDescriptors("%s", %s)' % (
                 self._env_name(), proto_descriptor_file, proto_srcs))
 
-    def _protoc_plugin_rules(self):
-        """Generate scons rules for each protoc plugin. """
-        env_name = self._env_name()
-        config = configparse.blade_config.get_config('protoc_plugin_config')
-        for plugin in self.data['protoc_plugins']:
-            p = config[plugin]
-            self._write_rule('%s.Append(PROTOC%sPLUGINFLAGS = "%s ")' % (
-                             env_name, p.language.upper(),
-                             p.protoc_plugin_flag(self.build_path)))
-
     def scons_rules(self):
         """scons_rules.
 
@@ -358,8 +288,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
 
         options = self.blade.get_options()
         direct_targets = self.blade.get_direct_targets()
-
-        self._protoc_plugin_rules()
 
         if (getattr(options, 'generate_java', False) or
             self.data.get('generate_java') or
@@ -423,7 +351,6 @@ def proto_library(name,
                   optimize=[],
                   deprecated=False,
                   generate_descriptors=False,
-                  plugins=[],
                   source_encoding='iso-8859-1',
                   **kwargs):
     """proto_library target. """
@@ -433,7 +360,6 @@ def proto_library(name,
                                         optimize,
                                         deprecated,
                                         generate_descriptors,
-                                        plugins,
                                         source_encoding,
                                         blade.blade,
                                         kwargs)

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -1235,13 +1235,13 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
         colors('green'), colors('purple'), colors('green'), colors('end')))
 
     proto_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --cpp_out=%s $SOURCE" % (
+        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --cpp_out=%s $PROTOCCPPPLUGINFLAGS $SOURCE" % (
             protoc_bin, protobuf_incs_str, build_dir),
         compile_proto_cc_message))
     top_env.Append(BUILDERS = {"Proto" : proto_bld})
 
     proto_java_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. --proto_path=%s --java_out=%s/`dirname $SOURCE` $SOURCE" % (
+        "%s --proto_path=. --proto_path=%s --java_out=%s/`dirname $SOURCE` $PROTOCJAVAPLUGINFLAGS $SOURCE" % (
             protoc_java_bin, protobuf_path, build_dir),
         compile_proto_java_message))
     top_env.Append(BUILDERS = {"ProtoJava" : proto_java_bld})
@@ -1253,7 +1253,7 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
     top_env.Append(BUILDERS = {"ProtoPhp" : proto_php_bld})
 
     proto_python_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --python_out=%s $SOURCE" % (
+        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --python_out=%s $PROTOCPYTHONPLUGINFLAGS $SOURCE" % (
             protoc_bin, protobuf_incs_str, build_dir),
         compile_proto_python_message))
     top_env.Append(BUILDERS = {"ProtoPython" : proto_python_bld})
@@ -1274,6 +1274,10 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
         '$SOURCES' % (protoc_bin, protobuf_incs_str),
         generate_proto_descriptor_message))
     top_env.Append(BUILDERS = {"ProtoDescriptors" : proto_descriptor_bld})
+
+    top_env.Replace(PROTOCCPPPLUGINFLAGS = "",
+                    PROTOCJAVAPLUGINFLAGS = "",
+                    PROTOCPYTHONPLUGINFLAGS = "")
 
     top_env.Append(PROTOPATH = ['.', protobuf_path])
     proto_scanner = top_env.Scanner(name = 'ProtoScanner',

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -1235,13 +1235,13 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
         colors('green'), colors('purple'), colors('green'), colors('end')))
 
     proto_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --cpp_out=%s $PROTOCCPPPLUGINFLAGS $SOURCE" % (
+        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --cpp_out=%s $SOURCE" % (
             protoc_bin, protobuf_incs_str, build_dir),
         compile_proto_cc_message))
     top_env.Append(BUILDERS = {"Proto" : proto_bld})
 
     proto_java_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. --proto_path=%s --java_out=%s/`dirname $SOURCE` $PROTOCJAVAPLUGINFLAGS $SOURCE" % (
+        "%s --proto_path=. --proto_path=%s --java_out=%s/`dirname $SOURCE` $SOURCE" % (
             protoc_java_bin, protobuf_path, build_dir),
         compile_proto_java_message))
     top_env.Append(BUILDERS = {"ProtoJava" : proto_java_bld})
@@ -1253,7 +1253,7 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
     top_env.Append(BUILDERS = {"ProtoPhp" : proto_php_bld})
 
     proto_python_bld = SCons.Builder.Builder(action = MakeAction(
-        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --python_out=%s $PROTOCPYTHONPLUGINFLAGS $SOURCE" % (
+        "%s --proto_path=. -I. %s -I=`dirname $SOURCE` --python_out=%s $SOURCE" % (
             protoc_bin, protobuf_incs_str, build_dir),
         compile_proto_python_message))
     top_env.Append(BUILDERS = {"ProtoPython" : proto_python_bld})
@@ -1274,10 +1274,6 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
         '$SOURCES' % (protoc_bin, protobuf_incs_str),
         generate_proto_descriptor_message))
     top_env.Append(BUILDERS = {"ProtoDescriptors" : proto_descriptor_bld})
-
-    top_env.Replace(PROTOCCPPPLUGINFLAGS = "",
-                    PROTOCJAVAPLUGINFLAGS = "",
-                    PROTOCPYTHONPLUGINFLAGS = "")
 
     top_env.Append(PROTOPATH = ['.', protobuf_path])
     proto_scanner = top_env.Scanner(name = 'ProtoScanner',


### PR DESCRIPTION
### Notice:

- Support only @@protoc_insertion_point of protoc, i.e. plugins **DONOT** generate their own files.

- Supported languages: cpp, java, python

### Usage:

1. Define a protoc plugin in BLADE_ROOT

![image](https://cloud.githubusercontent.com/assets/14238472/19920831/fecc03ce-a115-11e6-898f-52f49c1bec8b.png)

2. Assign a protoc plugin for proto_library

![image](https://cloud.githubusercontent.com/assets/14238472/19883365/e736a4f2-a04e-11e6-8fe2-1c8c2fe403be.png)

