### PR TITLE
Terminate worker threads with Ctrl+C

### DIFF
--- a/src/blade/test_scheduler.py
+++ b/src/blade/test_scheduler.py
@@ -41,6 +41,7 @@ class WorkerThread(threading.Thread):
         """Init methods for this thread. """
         threading.Thread.__init__(self)
         self.thread_id = id
+        self.running = True
         self.job_queue = job_queue
         self.job_handler = job_handler
         self.redirect = redirect
@@ -55,6 +56,10 @@ class WorkerThread(threading.Thread):
         """Private handler to handle one job. """
         console.info('blade worker %d starts to process' % self.thread_id)
         console.info('blade worker %d finish' % self.thread_id)
+
+    def terminate(self):
+        """Terminate the worker. """
+        self.running = False
 
     def cleanup_job(self):
         """Clean up job data. """
@@ -91,7 +96,7 @@ class WorkerThread(threading.Thread):
         try:
             if self.job_handler:
                 job_queue = self.job_queue
-                while not job_queue.empty():
+                while not job_queue.empty() and self.running:
                     try:
                         job = job_queue.get_nowait()
                     except Queue.Empty:
@@ -240,19 +245,25 @@ class TestScheduler(object):
         """Wait for worker threads to complete. """
         config = configparse.blade_config.get_config('global_config')
         test_timeout = config['test_timeout']
-        while threads:
-            time.sleep(1)  # Check every second
-            now = time.time()
-            dead_threads = []
-            for t in threads:
-                if t.isAlive():
-                    if test_timeout is not None:
-                        t.check_job_timeout(now)
-                else:
-                    dead_threads.append(t)
+        try:
+            while threads:
+                time.sleep(1)  # Check every second
+                now = time.time()
+                dead_threads = []
+                for t in threads:
+                    if t.isAlive():
+                        if test_timeout is not None:
+                            t.check_job_timeout(now)
+                    else:
+                        dead_threads.append(t)
 
-            for dt in dead_threads:
-                threads.remove(dt)
+                for dt in dead_threads:
+                    threads.remove(dt)
+        except KeyboardInterrupt:
+            console.error('KeyboardInterrupt: Terminate workers...')
+            for t in threads:
+                t.terminate()
+            raise
 
     def schedule_jobs(self):
         """scheduler. """


### PR DESCRIPTION
#### Terminate test worker threads in case of KeyboardInterrupt issued by Ctrl+C
#### Test: Write a few cc_test's each of which simply sleeps for 60 seconds and run them all by `blade 

- Tests don't stop by Ctrl+C:

![blade_sigint](https://user-images.githubusercontent.com/14238472/27577060-e32e6930-5b51-11e7-9ada-ccbf74c4cc70.png) 

- Tests stop by Ctrl+C immediately with this fix:

![blade_exit](https://user-images.githubusercontent.com/14238472/27577105-0ca742a0-5b52-11e7-989a-ef2b68f0732d.png)
