### PR TITLE
Optimize generated Sconstruct

### DIFF
--- a/src/blade/blade.py
+++ b/src/blade/blade.py
@@ -306,6 +306,10 @@ class Blade(object):
         """Return the blade root path. """
         return self.__root_dir
 
+    def get_command(self):
+        """Get the blade command. """
+        return self.__command
+
     def set_current_source_path(self, current_source_path):
         """Set the current source path. """
         self.__current_source_path = current_source_path

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -544,8 +544,9 @@ class JavaTargetMixIn(object):
         self._generate_regular_resources(resources, resources_var_name,
                                          resources_path_var_name)
         self._generate_location_resources(locations, resources_var_name)
-        self._write_rule('%s.Clean(%s, "%s")' % (
-            env_name, resources_var_name, resources_dir))
+        if self.blade.get_command() == 'clean':
+            self._write_rule('%s.Clean(%s, "%s")' % (
+                             env_name, resources_var_name, resources_dir))
         return resources_var_name, resources_path_var_name
 
     def _generate_generated_java_jar(self, var_name, srcs):
@@ -562,7 +563,9 @@ class JavaTargetMixIn(object):
         # BladeJavaJar builder puts the generated classes
         # into .class directory during jar building
         classes_dir = self._get_classes_dir()
-        self._write_rule('%s.Clean(%s, "%s")' % (env_name, var_name, classes_dir))
+        if self.blade.get_command() == 'clean':
+            self._write_rule('%s.Clean(%s, "%s")' % (
+                             env_name, var_name, classes_dir))
         return var_name
 
     def _generate_fat_jar(self, dep_jar_vars, dep_jars):

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -319,14 +319,17 @@ import scons_helper
         self._setup_envs()
 
     def _setup_envs(self):
-        env_with_error, env_no_warning = 'env_with_error', 'env_no_warning'
-        for env in [env_with_error, env_no_warning]:
+        self._setup_env_cc()
+        self._setup_env_java()
+
+    def _setup_env_cc(self):
+        env_cc_warning, env_cc = 'env_cc_warning', 'env_cc'
+        for env in [env_cc_warning, env_cc]:
             self._add_rule('%s = top_env.Clone()' % env)
 
         warnings, cxx_warnings, c_warnings = self.ccflags_manager.get_warning_flags()
         self._add_rule('%s.Append(CPPFLAGS=%s, CFLAGS=%s, CXXFLAGS=%s)' % (
-                       env_with_error, warnings, c_warnings, cxx_warnings))
-        self._setup_env_java()
+                       env_cc_warning, warnings, c_warnings, cxx_warnings))
 
     def _setup_env_java(self):
         env_java = 'env_java'


### PR DESCRIPTION
- Generate env.Clean only if 'blade clean'
- Omits objs var when there is only one source in CcTarget