### PR TITLE
fix a blade_error_log issue

### DIFF
--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -64,6 +64,7 @@ build_time = time.time()
 
 
 def set_blade_error_log(path):
+    global blade_error_log
     if blade_error_log:
         console.warning('blade error log was already set to %s' %
                         blade_error_log.name)


### PR DESCRIPTION
The patch fix the following critical issue:


Blade(info): ccache found
Blade(info): loading BUILDs...
Blade(info): loading done.
Blade(info): analyzing dependency graph...
Blade(info): analyzing done.
Blade(info): generating build rules...
Blade(info): CPP=cpp
Blade(info): CC=gcc
Blade(info): CXX=g++
Blade(info): LD=g++
Blade(info): generating done.
Blade(info): tunes the parallel jobs number(-j N) to be 4
scons: Reading SConscript files ...
UnboundLocalError: local variable 'blade_error_log' referenced before assignment:
  File "/home/kimi/nimitz/SConstruct", line 21:
    scons_helper.set_blade_error_log("build64_release/blade_scons.log.error")
  File "/home/kimi/typhoon-blade/src/blade/scons_helper.py", line 68:
    if blade_error_log:
Blade(error): building failure
Blade(info): cost time is 0:00:00s