### PR TITLE
Ninja build system part 2

### DIFF
--- a/src/blade/blade_util.py
+++ b/src/blade/blade_util.py
@@ -15,8 +15,10 @@
 
 import fcntl
 import os
+import sys
 import re
 import string
+import signal
 import subprocess
 
 import console
@@ -153,6 +155,36 @@ if "check_output" not in dir( subprocess ):
             error.output = output
             raise error
         return output
+
+
+def _echo(stdout, stderr):
+    """Echo messages to stdout and stderr. """
+    if stdout:
+        sys.stdout.write(stdout)
+    if stderr:
+        sys.stderr.write(stderr)
+
+
+def shell(cmd, env=None):
+    if isinstance(cmd, list):
+        cmdline = ' '.join(cmd)
+    else:
+        cmdline = cmd
+    p = subprocess.Popen(cmdline,
+                         env=env,
+                         stderr=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+                         shell=True)
+    stdout, stderr = p.communicate()
+    if p.returncode:
+        if p.returncode != -signal.SIGINT:
+            # Error
+            _echo(stdout, stderr)
+    else:
+        # Warnings
+        _echo(stdout, stderr)
+
+    return p.returncode
 
 
 def environ_add_path(env, key, path):

--- a/src/blade/fatjar.py
+++ b/src/blade/fatjar.py
@@ -14,7 +14,9 @@ into a single fatjar file.
 import os
 import sys
 import zipfile
+import console
 
+console_logging = False
 
 _JAR_MANIFEST = 'META-INF/MANIFEST.MF'
 _FATJAR_EXCLUSIONS = frozenset(['LICENSE', 'README', 'NOTICE',
@@ -72,8 +74,12 @@ def generate_fat_jar(target, jars):
 
     if zip_path_conflicts:
         log = '%s: Found %d conflicts when packaging.' % (target, zip_path_conflicts)
-        print >>sys.stdout, log
-        print >>sys.stderr, '\n'.join(zip_path_logs)
+        if console_logging:
+            console.warning(log)
+            console.debug('\n'.join(zip_path_logs))
+        else:
+            print >>sys.stdout, log
+            print >>sys.stderr, '\n'.join(zip_path_logs)
 
     # TODO(wentingli): Create manifest from dependency jars later if needed
     contents = 'Manifest-Version: 1.0\nCreated-By: Python.Zipfile (Blade)\n'

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -189,7 +189,7 @@ class JavaTargetMixIn(object):
     def __extract_dep_jars(self, dkey, dep_jars, maven_jars):
         """Extract jar file built by the target with the specified dkey.
 
-        dep_jars: a list of jars built by blade target. Each item is
+        dep_jars: a list of jars built by blade targets. Each item is
                   either a scons var or a file path depending on the build system.
         maven_jars: a list of jars managed by maven repository.
         """
@@ -616,7 +616,7 @@ class JavaTargetMixIn(object):
             ','.join(jar_vars), dep_jars))
         return var_name
 
-    def _ninja_generate_resources(self):
+    def ninja_generate_resources(self):
         resources = self.data['resources']
         locations = self.data['location_resources']
         if not resources and not locations:
@@ -638,7 +638,8 @@ class JavaTargetMixIn(object):
                 dst = os.path.basename(path)
             inputs.append(path)
             outputs.append(os.path.join(resources_dir, dst))
-        self.ninja_build(outputs, 'javaresource', inputs=inputs)
+        if inputs:
+            self.ninja_build(outputs, 'javaresource', inputs=inputs)
         return outputs
 
     def ninja_generate_fat_jar(self):
@@ -664,7 +665,7 @@ class JavaTargetMixIn(object):
                 vars['scalacflags'] = ' '.join(scalacflags)
         else:
             rule = 'javac'
-            vars = {'classes_dir' : self._target_file_path() + '.classes'}
+            vars = {'classes_dir' : self._get_classes_dir()}
             if javacflags:
                 vars['javacflags'] = ' '.join(javacflags)
         dep_jars, maven_jars = self._get_compile_deps()
@@ -783,7 +784,7 @@ class JavaTarget(Target, JavaTargetMixIn):
     def ninja_generate_jar(self):
         self._generate_sources(True)
         srcs = [self._source_file_path(s) for s in self.srcs]
-        resources = self._ninja_generate_resources()
+        resources = self.ninja_generate_resources()
         jar = self._target_file_path() + '.jar'
         if srcs and resources:
             classes_jar = self._target_file_path() + '__classes__.jar'

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -441,6 +441,7 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         return None
 
     def ninja_proto_java_rules(self, plugin_flags):
+        java_sources = []
         vars = self.ninja_protoc_plugin_vars(plugin_flags, 'java')
         for src in self.srcs:
             input = self._source_file_path(src)
@@ -448,6 +449,10 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             output = self._target_file_path(os.path.join(os.path.dirname(src),
                                                          package_dir, java_name))
             self.ninja_build(output, 'protojava', inputs=input, variables=vars)
+            java_sources.append(output)
+
+        self.ninja_build_jar(inputs=java_sources,
+                             source_encoding=self.data.get('source_encoding'))
 
     def ninja_proto_python_rules(self, plugin_flags):
         # vars = self.ninja_protoc_plugin_vars(plugin_flags, 'python')

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -431,7 +431,8 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
     def ninja_proto_descriptor_rules(self):
         inputs = [self._source_file_path(s) for s in self.srcs]
         output = self._proto_gen_descriptor_file(self.name)
-        self.ninja_build(output, 'protodescriptors', inputs=inputs)
+        self.ninja_build(output, 'protodescriptors', inputs=inputs,
+                         variables={ 'first' : inputs[0] })
 
     def ninja_protoc_plugin_vars(self, flags, language):
         if language in flags:

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -526,7 +526,7 @@ protocpythonpluginflags =
                                    protoc, protobuf_incs, self.build_dir),
                            description='PROTOCPYTHON ${in}')
         self.generate_rule(name='protodescriptors',
-                           command='%s --proto_path=. %s -I=`dirname ${in}` '
+                           command='%s --proto_path=. %s -I=`dirname ${first}` '
                                    '--descriptor_set_out=${out} --include_imports '
                                    '--include_source_info ${in}' % (
                                    protoc, protobuf_incs),

--- a/src/blade/rules_generator.py
+++ b/src/blade/rules_generator.py
@@ -392,11 +392,12 @@ import scons_helper
 
 
 class NinjaScriptHeaderGenerator(ScriptHeaderGenerator):
-    def __init__(self, options, build_dir, gcc_version,
+    def __init__(self, options, build_dir, blade_path, gcc_version,
                  python_inc, cuda_inc, build_environment, svn_roots):
         ScriptHeaderGenerator.__init__(
                 self, options, build_dir, gcc_version,
                 python_inc, cuda_inc, build_environment, svn_roots)
+        self.blade_path = blade_path
 
     def generate_rule(self, name, command, description=None,
                       depfile=None, generator=False, pool=None,
@@ -515,8 +516,8 @@ protocpythonpluginflags =
                                    protoc, protobuf_incs, self.build_dir),
                            description='PROTOC ${in}')
         self.generate_rule(name='protojava',
-                           command='%s --proto_path=. %s -I=`dirname ${in}` '
-                                   '--java_out=%s ${protocjavapluginflags} ${in}' % (
+                           command='%s --proto_path=. %s --java_out=%s/`dirname ${in}` '
+                                   '${protocjavapluginflags} ${in}' % (
                                    protoc_java, protobuf_java_incs, self.build_dir),
                            description='PROTOCJAVA ${in}')
         self.generate_rule(name='protopython',
@@ -531,10 +532,10 @@ protocpythonpluginflags =
                                    protoc, protobuf_incs),
                            description='PROTODESCRIPTORS ${in}')
 
-    def generate_resource_rules(self, blade_path):
+    def generate_resource_rules(self):
         self.generate_rule(name='resource_index',
                            command=self.generate_toolchain_command(
-                               blade_path, 'resource_index', 'TARGET_NAME=${name} SOURCE_PATH=${path}'),
+                               'resource_index', 'TARGET_NAME=${name} SOURCE_PATH=${path}'),
                            description='RESOURCE INDEX ${out}')
         self.generate_rule(name='resource',
                            command='xxd -i ${in} | '
@@ -542,18 +543,131 @@ protocpythonpluginflags =
                                    '-e "s/^unsigned int /const unsigned int RESOURCE_/g" > ${out}',
                            description='RESOURCE ${in}')
 
-    def generate_toolchain_command(self, blade_path, builder, prefix):
-        python_path = 'PYTHONPATH=%s:$$PYTHONPATH' % blade_path
-        return '%s %s python -m toolchain %s ${out} ${in}' % (
-               python_path, prefix, builder)
+    def generate_javac_rules(self, java_config):
+        java_home = java_config['java_home']
+        javac = os.path.join(java_home, 'bin', 'javac')
+        jar = os.path.join(java_home, 'bin', 'jar')
+        cmd = [javac]
+        version = java_config['version']
+        source_version = java_config.get('source_version', version)
+        target_version = java_config.get('target_version', version)
+        if source_version:
+            cmd.append('-source %s' % source_version)
+        if target_version:
+            cmd.append('-target %s' % target_version)
+        cmd += [
+            '-encoding ${source_encoding}',
+            '-d ${classes_dir}',
+            '-classpath ${classpath}',
+            '${javacflags}',
+            '${in}',
+        ]
+        self._add_rule('''
+source_encoding = UTF-8
+classpath = .
+javacflags =
+''')
+        self.generate_rule(name='javac',
+                           command='rm -fr ${classes_dir} && mkdir -p ${classes_dir} && '
+                                   '%s && sleep 0.5 && '
+                                   '%s cf ${out} -C ${classes_dir} .' % (
+                                   ' '.join(cmd), jar),
+                           description='JAVAC ${in}')
 
-    def generate(self, blade_path):
+    def generate_java_resource_rules(self):
+        self.generate_rule(name='javaresource',
+                           command=self.generate_toolchain_command('java_resource'),
+                           description='JAVA RESOURCE ${in}')
+
+    def generate_java_test_rules(self):
+        java_test_config = self.blade_config.get_config('java_test_config')
+        jacoco_home = java_test_config['jacoco_home']
+        if jacoco_home:
+            jacoco_agent = os.path.join(jacoco_home, 'lib', 'jacocoagent.jar')
+            prefix = 'JACOCOAGENT=%s' % jacoco_agent
+        else:
+            prefix = ''
+        self._add_rule('javatargetundertestpkg = __targetundertestpkg__')
+        args = '${mainclass} ${javatargetundertestpkg} ${out} ${in}'
+        self.generate_rule(name='javatest',
+                           command=self.generate_toolchain_command('java_test',
+                                                                   prefix=prefix,
+                                                                   suffix=args),
+                           description='JAVA TEST ${out}')
+
+    def generate_java_binary_rules(self):
+        config = self.blade_config.get_config('java_binary_config')
+        bootjar = config['one_jar_boot_jar']
+        args = '%s ${mainclass} ${out} ${in}' % bootjar
+        self.generate_rule(name='onejar',
+                           command=self.generate_toolchain_command('java_onejar', suffix=args),
+                           description='ONE JAR ${out}')
+        self.generate_rule(name='javabinary',
+                           command=self.generate_toolchain_command('java_binary'),
+                           description='JAVA BIN ${out}')
+
+    def generate_scala_rules(self, java_home):
+        scala_config = self.blade_config.get_config('scala_config')
+        scala_home = scala_config['scala_home']
+        scala = os.path.join(scala_home, 'bin', 'scala')
+        scalac = os.path.join(scala_home, 'bin', 'scalac')
+        java = os.path.join(java_home, 'bin', 'java')
+        self._add_rule('''
+scalacflags = -nowarn
+''')
+        cmd = [
+            'JAVACMD=%s' % java,
+            scalac,
+            '-encoding UTF8',
+            '-d ${out}',
+            '-classpath ${classpath}',
+            '${scalacflags}',
+            '${in}'
+        ]
+        self.generate_rule(name='scalac',
+                           command=' '.join(cmd),
+                           description='SCALAC ${out}')
+        args = '%s %s ${out} ${in}' % (java, scala)
+        self.generate_rule(name='scalatest',
+                           command=self.generate_toolchain_command('scala_test', suffix=args),
+                           description='SCALA TEST ${out}')
+
+    def generate_java_scala_rules(self):
+        java_config = self.blade_config.get_config('java_config')
+        self.generate_javac_rules(java_config)
+        self.generate_java_resource_rules()
+        java_home = java_config['java_home']
+        jar = os.path.join(java_home, 'bin', 'jar')
+        args = '%s ${out} ${in}' % jar
+        self.generate_rule(name='javajar',
+                           command=self.generate_toolchain_command('java_jar', suffix=args),
+                           description='JAVA JAR ${out}')
+        self.generate_java_test_rules()
+        self.generate_rule(name='fatjar',
+                           command=self.generate_toolchain_command('java_fatjar'),
+                           description='FAT JAR ${out}')
+        self.generate_java_binary_rules()
+        self.generate_scala_rules(java_home)
+
+    def generate_toolchain_command(self, builder, prefix='', suffix=''):
+        cmd = ['PYTHONPATH=%s:$$PYTHONPATH' % self.blade_path]
+        if prefix:
+            cmd.append(prefix)
+        cmd.append('python -m toolchain %s' % builder)
+        if suffix:
+            cmd.append(suffix)
+        else:
+            cmd.append('${out} ${in}')
+        return ' '.join(cmd)
+
+    def generate(self):
         """Generate ninja rules. """
         self.generate_top_level_vars()
         self.generate_common_rules()
         self.generate_cc_rules()
         self.generate_proto_rules()
-        self.generate_resource_rules(blade_path)
+        self.generate_resource_rules()
+        self.generate_java_scala_rules()
         return self.rules_buf
 
 
@@ -625,12 +739,13 @@ class NinjaRulesGenerator(RulesGenerator):
         ninja_script_header_generator = NinjaScriptHeaderGenerator(
                 options,
                 self.build_dir,
+                self.blade_path,
                 gcc_version,
                 python_inc,
                 cuda_inc,
                 self.blade.build_environment,
                 self.blade.svn_root_dirs)
-        rules = ninja_script_header_generator.generate(self.blade_path)
+        rules = ninja_script_header_generator.generate()
         rules += self.blade.gen_targets_rules()
         return rules
 

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -121,15 +121,16 @@ class ScalaTarget(Target, JavaTargetMixIn):
         if target_platform:
             flags.append('-target:%s' % target_platform)
         warnings = self.data.get('warnings')
-        if not warnings:
-            warnings = config['warnings']
         if warnings:
             flags.append(warnings)
+        global_warnings = config['warnings']
+        if global_warnings:
+            flags.append(global_warnings)
         return flags
 
     def ninja_generate_jar(self):
         srcs = [self._source_file_path(s) for s in self.srcs]
-        resources = self._ninja_generate_resources()
+        resources = self.ninja_generate_resources()
         jar = self._target_file_path() + '.jar'
         if srcs and resources:
             classes_jar = self._target_file_path() + '__classes__.jar'

--- a/src/blade/scala_targets.py
+++ b/src/blade/scala_targets.py
@@ -114,6 +114,39 @@ class ScalaTarget(Target, JavaTargetMixIn):
         self._add_target_var('jar', var_name)
         return var_name
 
+    def scalac_flags(self):
+        flags = []
+        config = configparse.blade_config.get_config('scala_config')
+        target_platform = config['target_platform']
+        if target_platform:
+            flags.append('-target:%s' % target_platform)
+        warnings = self.data.get('warnings')
+        if not warnings:
+            warnings = config['warnings']
+        if warnings:
+            flags.append(warnings)
+        return flags
+
+    def ninja_generate_jar(self):
+        srcs = [self._source_file_path(s) for s in self.srcs]
+        resources = self._ninja_generate_resources()
+        jar = self._target_file_path() + '.jar'
+        if srcs and resources:
+            classes_jar = self._target_file_path() + '__classes__.jar'
+            scalacflags = self.scalac_flags()
+            self.ninja_build_jar(classes_jar, inputs=srcs,
+                                 scala=True, scalacflags=scalacflags)
+            self.ninja_build(jar, 'javajar', inputs=[classes_jar] + resources)
+        elif srcs:
+            scalacflags = self.scalac_flags()
+            self.ninja_build_jar(jar, inputs=srcs,
+                                 scala=True, scalacflags=scalacflags)
+        elif resources:
+            self.ninja_build(jar, 'javajar', inputs=resources)
+        else:
+            jar = ''
+        return jar
+
 
 class ScalaLibrary(ScalaTarget):
     """ScalaLibrary"""
@@ -133,6 +166,11 @@ class ScalaLibrary(ScalaTarget):
         if jar_var:
             self._add_default_target_var('jar', jar_var)
 
+    def ninja_rules(self):
+        jar = self.ninja_generate_jar()
+        if jar:
+            self._add_default_target_file('jar', jar)
+
 
 class ScalaFatLibrary(ScalaTarget):
     """ScalaFatLibrary"""
@@ -150,6 +188,10 @@ class ScalaFatLibrary(ScalaTarget):
         dep_jars = self._detect_maven_conflicted_deps('package', dep_jars)
         fatjar_var = self._generate_fat_jar(dep_jar_vars, dep_jars)
         self._add_default_target_var('fatjar', fatjar_var)
+
+    def ninja_rules(self):
+        jar = self.ninja_generate_fat_jar()
+        self._add_default_target_file('fatjar', jar)
 
 
 class ScalaTest(ScalaFatLibrary):
@@ -181,6 +223,16 @@ class ScalaTest(ScalaFatLibrary):
                              'source=[%s] + [%s] + %s)' % (
                     var_name, self._env_name(), self._target_file_path(),
                     jar_var, ','.join(dep_jar_vars), dep_jars))
+
+    def ninja_rules(self):
+        if not self.srcs:
+            console.warning('%s: Empty scala test sources.' % self.fullname)
+            return
+        jar = self.ninja_generate_jar()
+        output = self._target_file_path()
+        dep_jars, maven_jars = self._get_test_deps()
+        self.ninja_build(output, 'scalatest',
+                         inputs=[jar] + dep_jars + maven_jars)
 
 
 def scala_library(name,

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -346,14 +346,18 @@ class Target(object):
         
         Returns
         -----------
-        A tuple of (scons vars, jars)
+        A tuple of (target jars, maven jars)
         
         Description
         -----------
         Return java package dependencies excluding provided dependencies
-        scons vars represent targets to be built later
-        jars represent prebuilt jars or maven artifacts within local repository
-        
+
+        target jars represent either a scons var or a path to jar archive
+        depending on the underlying build system in use. Each jar is built
+        by java_library(prebuilt)/scala_library/proto_library.
+
+        maven jars represent maven artifacts within local repository built
+        by maven_jar(...).
         """
         return [], []
 

--- a/src/blade/toolchain.py
+++ b/src/blade/toolchain.py
@@ -30,7 +30,6 @@ import os
 import sys
 import subprocess
 import shutil
-import time
 import zipfile
 
 import blade_util


### PR DESCRIPTION
### Main changes

1. Change variable naming in JavaMixIn dependency handling methods(compile/package/test_deps) in order to unify scons and ninja build system.

   - dep_jar_vars --> dep_jars: represent jars built by blade targets, including java_library(prebuilt)/scala_library/proto_library

   - dep_jars --> maven_jars: represent jars introduced from maven_jar

2. Ninja build/rules for java_library/java_fat_library/java_binary/java_test

3. Ninja java build for proto_library

4. Ninja build/rules for scala_library/scala_fat_library/scala_test
