### PR TITLE
refactoring command args and add profiling

### DIFF
--- a/src/blade/blade.py
+++ b/src/blade/blade.py
@@ -136,7 +136,7 @@ class Blade(object):
         return self.__build_targets  # For test
 
     def get_build_rules_generator(self):
-        if self.__options.ninja_build:
+        if self.__options.native_builder == 'ninja':
             return NinjaRulesGenerator('build.ninja', self.__blade_path, self)
         else:
             return SconsRulesGenerator('SConstruct', self.__blade_path, self)
@@ -151,8 +151,6 @@ class Blade(object):
 
     def generate(self):
         """Generate the build script. """
-        self.load_targets()
-        self.analyze_targets()
         if self.__command != 'query':
             self.generate_build_rules()
 
@@ -377,8 +375,6 @@ class Blade(object):
         rules_buf = []
         skip_test = getattr(self.__options, 'no_test', False)
         skip_package = not getattr(self.__options, 'generate_package', False)
-        scons_build = getattr(self.__options, 'scons_build', False)
-        ninja_build = getattr(self.__options, 'ninja_build', False)
         for k in self.__sorted_targets_keys:
             target = self.__build_targets[k]
             if not self._is_scons_object_type(target.type):
@@ -394,7 +390,7 @@ class Blade(object):
                 and k not in self.__direct_targets):
                 continue
 
-            if ninja_build:
+            if self.__options.native_builder == 'ninja':
                 blade_object.ninja_rules()
             else:
                 blade_object.scons_rules()

--- a/src/blade/blade_main.py
+++ b/src/blade/blade_main.py
@@ -434,12 +434,10 @@ def _main(blade_path):
     lock_file_fd = lock_workspace()
     try:
         if options.profiling:
-            restats_file = os.path.join(build_dir, 'restats')
             pstats_file = os.path.join(build_dir, 'blade.pstats')
             cProfile.runctx("run_subcommand(command, options, targets, blade_path, build_dir)",
-                            globals(), locals(), restats_file)
-            p = pstats.Stats(restats_file)
-            p.dump_stats(pstats_file)
+                            globals(), locals(), pstats_file)
+            p = pstats.Stats(pstats_file)
             p.sort_stats('cumulative').print_stats(20)
             p.sort_stats('time').print_stats(20)
             console.info('Binary result file %s is also generated, '

--- a/src/blade/cc_targets.py
+++ b/src/blade/cc_targets.py
@@ -482,7 +482,7 @@ class CcTarget(Target):
             return
 
         options = self.blade.get_options()
-        if options.ninja_build:
+        if options.native_builder == 'ninja':
             paths = self._prebuilt_cc_library_ninja_rules()
         else:
             paths = self._prebuilt_cc_library_scons_rules()

--- a/src/blade/command_args.py
+++ b/src/blade/command_args.py
@@ -62,23 +62,12 @@ class CmdArguments(object):
 
     def _check_run_targets(self):
         """check that run command should have only one target. """
-        err = False
-        targets = []
-        if len(self.targets) == 0:
-            err = True
-        elif self.targets[0].find(':') == -1:
-            err = True
-        if err:
+        if not self.targets or ':' not in self.targets[0]:
             console.error_exit('Please specify a single target to run: '
                                'blade run //target_path:target_name (or '
                                'a_path:target_name)')
-        if self.options.command == 'run' and len(self.targets) > 1:
+        if len(self.targets) > 1:
             console.warning('run command will only take one target to build and run')
-        if self.targets[0].startswith('//'):
-            targets.append(self.targets[0][2:])
-        else:
-            targets.append(self.targets[0])
-        self.targets = targets
         if self.options.runargs:
             console.warning('--runargs has been deprecated, please put all run'
                             ' arguments after a "--"')
@@ -150,17 +139,17 @@ class CmdArguments(object):
         """Add plat and profile arguments. """
         parser.add_argument('-m',
                             dest='m',
+                            choices=['32', '64', ''],
                             help=('Generate code for a 32-bit(-m32) or '
                                   '64-bit(-m64) environment, '
-                                  'default is autodetect.'))
+                                  'default is autodetect'))
 
         parser.add_argument('-p',
                             '--profile',
                             dest='profile',
                             choices=['debug', 'release'],
                             default='release',
-                            help=('Build profile: debug or release, '
-                                  'default is release.'))
+                            help=('Build profile, default is release'))
 
         parser.add_argument('--no-debug-info',
                             dest='no_debug_info',
@@ -168,52 +157,47 @@ class CmdArguments(object):
                             default=False,
                             help=('Do not produce debugging information, this '
                                   'make less disk space cost but hard to debug, '
-                                  'default is false.'))
+                                  'default is false'))
 
     def __add_generate_arguments(self, parser):
         """Add generate related arguments. """
         parser.add_argument(
             '--generate-dynamic', dest='generate_dynamic',
             action='store_true', default=False,
-            help='Generate dynamic libraries.')
+            help='Generate dynamic libraries')
 
         parser.add_argument(
             '--generate-package', dest='generate_package',
             action='store_true', default=False,
-            help='Generate packages for package target.')
+            help='Generate packages for package target')
 
         parser.add_argument(
             '--generate-java', dest='generate_java',
             action='store_true', default=False,
             help='Generate java files for proto_library, thrift_library and '
-                 'swig_library.')
+                 'swig_library')
 
         parser.add_argument(
             '--generate-php', dest='generate_php',
             action='store_true', default=False,
-            help='Generate php files for proto_library and swig_library.')
+            help='Generate php files for proto_library and swig_library')
 
         parser.add_argument(
             '--generate-python', dest='generate_python',
             action='store_true', default=False,
-            help='Generate python files for proto_library and thrift_library.')
+            help='Generate python files for proto_library and thrift_library')
 
         parser.add_argument(
             '--generate-go', dest='generate_go',
             action='store_true', default=False,
-            help='Generate go files for proto_library.')
+            help='Generate go files for proto_library')
 
     def __add_build_actions_arguments(self, parser):
         """Add build related action arguments. """
         parser.add_argument(
             '--native-builder', dest='native_builder',
             type=str, choices = ['scons', 'ninja'], default='scons',
-            help='Specific the underly native build, scons or ninja.')
-        parser.add_argument(
-            '--stop-after', dest='stop_after',
-            type=str, choices=['load', 'analyze', 'generate', 'build', 'all'],
-            default='all',
-            help='Stop after specified phase.')
+            help='Specify the underly native builder')
         parser.add_argument(
             '--generate-scons-only', dest='stop_after',
             action='store_const', const='generate',
@@ -223,45 +207,38 @@ class CmdArguments(object):
         """Add extra native builder options arguments. """
         parser.add_argument(
             '--native-builder-options', dest='native_builder_options', type=str,
-            help='Specifies extra native builder options, for debug purpose.')
+            help='Specifies extra native builder options, for debug purpose')
 
         parser.add_argument(
             '-j', '--jobs', dest='jobs', type=int, default=0,
-            help=('Specifies the number of jobs (commands) to '
-                  'run simultaneously.'))
+            help=('Specifies the number of jobs (commands) to run simultaneously'))
 
         parser.add_argument(
             '-k', '--keep-going', dest='keep_going',
             action='store_true', default=False,
-            help='Continue as much as possible after an error.')
+            help='Continue as much as possible after an error')
 
         parser.add_argument(
             '--verbose', dest='verbose', action='store_true',
-            default=False, help='Show all details.')
+            default=False, help='Show all details')
 
         parser.add_argument(
             '--no-test', dest='no_test', action='store_true',
-            default=False, help='Do not build the test targets.')
+            default=False, help='Do not build the test targets')
 
         parser.add_argument(
             '-n', '--dry-run', dest='dry_run', action='store_true', default=False,
             help='Dry run (don\'t run commands but act like they succeeded)')
 
-    def __add_color_arguments(self, parser):
-        """Add color argument. """
-        parser.add_argument(
-            '--color', dest='color', choices=['yes', 'no', 'auto'], default='auto',
-            help='Enable color: yes, no or auto, default is auto.')
-
     def __add_cache_arguments(self, parser):
         """Add cache related arguments. """
         parser.add_argument(
             '--cache-dir', dest='cache_dir', type=str,
-            help='Specifies location of shared cache directory.')
+            help='Specifies location of shared cache directory')
 
         parser.add_argument(
             '--cache-size', dest='cache_size', type=str,
-            help='Specifies cache size of shared cache directory in Gigabytes.'
+            help='Specifies cache size of shared cache directory in Gigabytes'
                  '"unlimited" for unlimited. ')
 
     def __add_coverage_arguments(self, parser):
@@ -269,84 +246,80 @@ class CmdArguments(object):
         parser.add_argument(
             '--gprof', dest='gprof',
             action='store_true', default=False,
-            help='Add build options to support GNU gprof.')
+            help='Add build options to support GNU gprof')
 
         parser.add_argument(
             '--gcov', dest='coverage',
             action='store_true', default=False,
             help='Add build options to support GNU gcov to do coverage test. '
-                 '--gcov is deprecated, please use --coverage.')
+                 'DEPRECATED, please use --coverage')
 
         parser.add_argument(
             '--coverage', dest='coverage',
             action='store_true', default=False,
-            help='Add build options to support coverage test.')
+            help='Add build options to support coverage test')
 
     def _add_query_arguments(self, parser):
         """Add query arguments for parser. """
         self.__add_plat_profile_arguments(parser)
-        self.__add_color_arguments(parser)
         parser.add_argument(
             '--deps', dest='deps',
             action='store_true', default=False,
-            help='Show all targets that depended by the target being queried.')
+            help='Show all targets that depended by the target being queried')
         parser.add_argument(
             '--depended', dest='depended',
             action='store_true', default=False,
-            help='Show all targets that depend on the target being queried.')
+            help='Show all targets that depend on the target being queried')
         parser.add_argument(
             '--output-to-dot', dest='output_to_dot', type=str,
-            help='The name of file to output query results as dot(graphviz) '
-                 'format.')
+            help='The name of file to output query results as dot(graphviz) format')
         parser.add_argument(
             '--output-tree', dest='output_tree',
             action='store_true', default=False,
-            help='Show the dependency tree of the specified target.')
+            help='Show the dependency tree of the specified target')
 
     def _add_clean_arguments(self, parser):
         """Add clean arguments for parser. """
         self.__add_plat_profile_arguments(parser)
         self.__add_build_actions_arguments(parser)
         self.__add_generate_arguments(parser)
-        self.__add_color_arguments(parser)
 
     def _add_test_arguments(self, parser):
         """Add test command arguments. """
         parser.add_argument(
             '--testargs', dest='testargs', type=str,
-            help='Command line arguments to be passed to tests.')
+            help='Command line arguments to be passed to tests')
 
         parser.add_argument(
             '--full-test', action='store_true',
             dest='fulltest', default=False,
-            help='Enable full test, default is incremental test.')
+            help='Enable full test, default is incremental test')
 
         parser.add_argument(
             '-t', '--test-jobs', dest='test_jobs', type=int, default=1,
-            help=('Specifies the number of tests to run simultaneously.'))
+            help=('Specifies the number of tests to run simultaneously'))
 
         parser.add_argument(
             '--show-details', action='store_true',
             dest='show_details', default=False,
-            help='Shows the test result in detail and provides a file.')
+            help='Shows the test result in detail and provides a file')
 
         parser.add_argument(
             '--no-build', action='store_true',
             dest='no_build', default=False,
-            help='Run tests directly without build.')
+            help='Run tests directly without build')
 
     def _add_run_arguments(self, parser):
         """Add run command arguments. """
         parser.add_argument(
             '--runargs', dest='runargs', type=str,
-            help='Command line arguments to be passed to the single run target.')
+            help='Command line arguments to be passed to the single run target')
 
     def _add_build_arguments(self, *parsers):
         """Add building arguments for parsers. """
         for parser in parsers:
             self.__add_plat_profile_arguments(parser)
             self.__add_build_actions_arguments(parser)
-            self.__add_color_arguments(parser)
             self.__add_cache_arguments(parser)
             self.__add_generate_arguments(parser)
             self.__add_coverage_arguments(parser)
@@ -355,7 +328,14 @@ class CmdArguments(object):
         for parser in parsers:
             parser.add_argument(
                 '--profiling', dest='profiling', action='store_true',
-                help='Performance profiling.')
+                help='Blade performance profiling, for blade developing')
+            parser.add_argument(
+                '--stop-after', dest='stop_after', type=str,
+                choices=['load', 'analyze', 'generate', 'build', 'all'], default='all',
+                help='Stop after specified phase')
+            parser.add_argument(
+                '--color', dest='color', choices=['yes', 'no', 'auto'], default='auto',
+                help='Output color mode selection')
 
 
     def _cmd_parse(self):

--- a/src/blade/console.py
+++ b/src/blade/console.py
@@ -131,3 +131,11 @@ def log(msg):
     """Dump message into log file. """
     if _log:
         print >>_log, msg
+
+def flush():
+    '''FLush '''
+    sys.stdout.flush()
+    sys.stderr.flush()
+    if _log:
+        _log.flush()
+

--- a/src/blade/java_targets.py
+++ b/src/blade/java_targets.py
@@ -195,7 +195,7 @@ class JavaTargetMixIn(object):
         """
         dep = self.target_database[dkey]
         options = self.blade.get_options()
-        if options.ninja_build:
+        if options.native_builder == 'ninja':
             jar = dep._get_target_file('jar')
         else:
             jar = dep._get_target_var('jar')

--- a/src/blade/scons_helper.py
+++ b/src/blade/scons_helper.py
@@ -420,7 +420,7 @@ def _generate_java_jar(target, sources, resources, env):
 
     if os.path.exists(resources_dir):
         for resource in resources:
-            cmd.append("-C '%s' '%s'" % (resources_dir, 
+            cmd.append("-C '%s' '%s'" % (resources_dir,
                     os.path.relpath(resource, resources_dir)))
 
     cmd = ' '.join(cmd)
@@ -1185,7 +1185,7 @@ def get_compile_source_message():
 
 
 def get_link_program_message():
-    return console.inerasable('%sLinking Program %s$TARGET%s%s' % (
+    return console.erasable('%sLinking Program %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
 
 
@@ -1198,13 +1198,13 @@ def setup_compliation_verbose(top_env, color_enabled, verbose):
     link_program_message = get_link_program_message()
     assembling_source_message = console.erasable('%sAssembling %s$SOURCE%s%s' % (
         colors('cyan'), colors('purple'), colors('cyan'), colors('end')))
-    link_library_message = console.inerasable('%sCreating Static Library %s$TARGET%s%s' % (
+    link_library_message = console.erasable('%sCreating Static Library %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
-    ranlib_library_message = console.inerasable('%sRanlib Library %s$TARGET%s%s' % (
+    ranlib_library_message = console.erasable('%sRanlib Library %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
-    link_shared_library_message = console.inerasable('%sLinking Shared Library %s$TARGET%s%s' % (
+    link_shared_library_message = console.erasable('%sLinking Shared Library %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
-    jar_message = console.inerasable('%sCreating Jar %s$TARGET%s%s' % (
+    jar_message = console.erasable('%sCreating Jar %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
 
     if not verbose:
@@ -1278,7 +1278,7 @@ def setup_proto_builders(top_env, build_dir, protoc_bin, protoc_java_bin,
     copy_proto_go_source_message = console.erasable('%sCopying %s$SOURCE%s to go directory%s' %
         (colors('cyan'), colors('purple'), colors('cyan'), colors('end')))
 
-    generate_proto_descriptor_message = console.inerasable('%sGenerating proto descriptor set %s$TARGET%s%s' % (
+    generate_proto_descriptor_message = console.erasable('%sGenerating proto descriptor set %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
 
     proto_bld = SCons.Builder.Builder(action = MakeAction(
@@ -1453,19 +1453,19 @@ def setup_java_builders(top_env, java_home, one_jar_boot_path):
         one_java_message))
     top_env.Append(BUILDERS = {'OneJar' : one_jar_bld})
 
-    fat_java_message = console.inerasable('%sCreating Fat Jar %s$TARGET%s%s' % ( \
+    fat_java_message = console.erasable('%sCreating Fat Jar %s$TARGET%s%s' % ( \
         colors('green'), colors('purple'), colors('green'), colors('end')))
     fat_jar_bld = SCons.Builder.Builder(action = MakeAction(generate_fat_jar,
         fat_java_message))
     top_env.Append(BUILDERS = {'FatJar' : fat_jar_bld})
 
-    java_binary_message = console.inerasable('%sGenerating Java Binary %s$TARGET%s%s' % \
+    java_binary_message = console.erasable('%sGenerating Java Binary %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     java_binary_bld = SCons.Builder.Builder(action = MakeAction(
         generate_java_binary, java_binary_message))
     top_env.Append(BUILDERS = {"JavaBinary" : java_binary_bld})
 
-    java_test_message = console.inerasable('%sGenerating Java Test %s$TARGET%s%s' % \
+    java_test_message = console.erasable('%sGenerating Java Test %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     java_test_bld = SCons.Builder.Builder(action = MakeAction(
         generate_java_test, java_test_message))
@@ -1481,7 +1481,7 @@ def setup_scala_builders(top_env, scala_home):
         generate_scala_jar, '$JARCOMSTR'))
     top_env.Append(BUILDERS = {"ScalaJar" : scala_jar_bld})
 
-    scala_test_message = console.inerasable('%sGenerating Scala Test %s$TARGET%s%s' % \
+    scala_test_message = console.erasable('%sGenerating Scala Test %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     scala_test_bld = SCons.Builder.Builder(action = MakeAction(
         generate_scala_test, scala_test_message))
@@ -1494,19 +1494,19 @@ def setup_go_builders(top_env, go_cmd, go_home):
     if go_home:
         top_env.Replace(GOHOME=go_home)
 
-    go_library_message = console.inerasable('%sGenerating Go Package %s$TARGET%s%s' %
+    go_library_message = console.erasable('%sGenerating Go Package %s$TARGET%s%s' %
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     go_library_builder = SCons.Builder.Builder(action = MakeAction(
         generate_go_library, go_library_message))
     top_env.Append(BUILDERS = {"GoLibrary" : go_library_builder})
 
-    go_binary_message = console.inerasable('%sGenerating Go Executable %s$TARGET%s%s' %
+    go_binary_message = console.erasable('%sGenerating Go Executable %s$TARGET%s%s' %
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     go_binary_builder = SCons.Builder.Builder(action = MakeAction(
         generate_go_binary, go_binary_message))
     top_env.Append(BUILDERS = {"GoBinary" : go_binary_builder})
 
-    go_test_message = console.inerasable('%sGenerating Go Test %s$TARGET%s%s' %
+    go_test_message = console.erasable('%sGenerating Go Test %s$TARGET%s%s' %
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     go_test_builder = SCons.Builder.Builder(action = MakeAction(
         generate_go_test, go_test_message))
@@ -1532,11 +1532,11 @@ def setup_resource_builders(top_env):
 
 
 def setup_python_builders(top_env):
-    compile_python_egg_message = console.inerasable('%sGenerating Python Egg %s$TARGET%s%s' % \
+    compile_python_egg_message = console.erasable('%sGenerating Python Egg %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
-    compile_python_library_message = console.inerasable('%sGenerating Python Library %s$TARGET%s%s' % \
+    compile_python_library_message = console.erasable('%sGenerating Python Library %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
-    compile_python_binary_message = console.inerasable('%sGenerating Python Binary %s$TARGET%s%s' % \
+    compile_python_binary_message = console.erasable('%sGenerating Python Binary %s$TARGET%s%s' % \
         (colors('green'), colors('purple'), colors('green'), colors('end')))
 
     python_egg_bld = SCons.Builder.Builder(action = MakeAction(generate_python_egg,
@@ -1557,7 +1557,7 @@ def setup_package_builders(top_env):
         action = MakeAction(process_package_source, source_message))
     top_env.Append(BUILDERS = {"PackageSource" : source_bld})
 
-    package_message = console.inerasable('%sCreating Package %s$TARGET%s%s' % (
+    package_message = console.erasable('%sCreating Package %s$TARGET%s%s' % (
         colors('green'), colors('purple'), colors('green'), colors('end')))
     package_bld = SCons.Builder.Builder(
         action = MakeAction(generate_package, package_message))
@@ -1571,7 +1571,7 @@ def setup_shell_builders(top_env):
         generate_shell_test_data, shell_test_data_message))
     top_env.Append(BUILDERS = {"ShellTestData" : shell_test_data_bld})
 
-    shell_test_message = console.inerasable('%sGenerating Shell Test %s$TARGET%s%s' %
+    shell_test_message = console.erasable('%sGenerating Shell Test %s$TARGET%s%s' %
         (colors('green'), colors('purple'), colors('green'), colors('end')))
     shell_test_bld = SCons.Builder.Builder(action = MakeAction(
         generate_shell_test, shell_test_message))

--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -309,7 +309,7 @@ class Target(object):
         which means this target is visible globally within the code base.
         Note that targets inside the same BUILD file are always visible
         to each other.
-        
+
         """
         if visibility is None:
             return
@@ -343,11 +343,11 @@ class Target(object):
 
     def _get_java_pack_deps(self):
         """_get_java_pack_deps
-        
+
         Returns
         -----------
         A tuple of (target jars, maven jars)
-        
+
         Description
         -----------
         Return java package dependencies excluding provided dependencies


### PR DESCRIPTION
add --dry-run, --profiling
ninja support -j -k
merge --ninja-build and --scons-build into one single --native-builder
improve --generate-scons-only to --stop-after
enum args such as --color uses 'choices' instead of manual checking
support performance profiling