### PR TITLE
Fix Target._get_target_files when value is a list of paths

### DIFF
--- a/src/blade/target.py
+++ b/src/blade/target.py
@@ -604,7 +604,13 @@ class Target(object):
         All the target files built by the target itself
 
         """
-        return self.data['targets'].values()
+        results = set()
+        for _, v in self.data['targets'].iteritems():
+            if isinstance(v, list):
+                results.update(v)
+            else:
+                results.add(v)
+        return sorted(results)
 
     def _generate_header_files(self):
         """Whether this target generates header files during building. """


### PR DESCRIPTION
Normally a target may have more than one output built by different rules, such as proto_library may generate various outputs according to the build targets and options. 

The output for each kind of the rule is usually a single path within build directory, but could be a list of path. Currently proto_library outputs for golang is recorded this way:

    'gopkg'  ->  ['protobuf_go_path/common/framework/rpc/rpc_options.pb.go',
                   protobuf_go_path/common/framework/rpc/rpc_error_code.pb.go,
                   protobuf_go_path/common/framework/rpc/rpc_monitor.pb.go]
